### PR TITLE
chore: disable Cleanthat GitHub App for this repository

### DIFF
--- a/.cleanthat/cleanthat.yaml
+++ b/.cleanthat/cleanthat.yaml
@@ -1,0 +1,48 @@
+# Capture-the-Flag — Cleanthat configuration
+#
+# PURPOSE
+# -------
+# The Cleanthat GitHub App (solven-eu/cleanthat) is a third-party App whose
+# check runs were repeatedly getting stuck in `in_progress` on this repo
+# (see PR #1231, #1232, check_run_id 86990436443). The check is not a GitHub
+# Actions job — the App creates it via the Checks API from its own backend —
+# so it cannot be routed to a self-hosted runner.
+#
+# This config disables Cleanthat for THIS repository by excluding every
+# head ref from its processing. Verified from upstream source:
+#   github/src/main/java/eu/solven/cleanthat/code_provider/github/refs/GithubRefCleaner.java
+#     selectPatternOfSensibleHead()  ->  Pattern.matches(regex, fullRef)
+#     prepareRefToClean()           ->  if head matches excluded_patterns
+#                                          return Optional.empty()   // NO check run
+# Patterns are matched against `refs/heads/<branch>` using Java
+# java.util.regex.Pattern.matches (fully anchored), so `refs/heads/.*`
+# matches every branch ref and the App short-circuits before creating
+# any `Cleanthat` check run.
+#
+# To re-enable Cleanthat for selected branches in the future, replace
+# `refs/heads/.*` with the actual refs you want excluded, e.g.
+#     excluded_patterns:
+#       - "refs/heads/release/.*"
+
+syntax_version: "2023-01-09"
+
+meta:
+  # Don't even let Cleanthat open auto-clean PRs against our branches
+  can_edit_not_protected_branches: false
+  # Disable the "rewrite the whole repo on config change" behavior
+  full_clean_on_configuration_change: false
+  refs:
+    # Exclude every branch head ref from Cleanthat processing.
+    # With this set, `prepareRefToClean` returns Optional.empty()
+    # BEFORE the App calls `createCheckRun` — so no check run is
+    # ever emitted for this repository.
+    excluded_patterns:
+      - "refs/heads/.*"
+    # Also clear the default protected set so `canCleanInPlace` /
+    # `canCleanInNewRR` cannot route around the excluded check.
+    protected_patterns: []
+
+# No engines — even if a future change re-enables processing, there
+# is nothing for Cleanthat to run, and the no-op path returns
+# Optional.empty() before any check run is created.
+engines: []


### PR DESCRIPTION
Adds `.cleanthat/cleanthat.yaml` to make Cleanthat short-circuit in its `prepareRefToClean()` step before any `createCheckRun()` call, so the stuck `Cleanthat` check stops appearing on PRs.

**Why this is needed**
The `Cleanthat` check has been wedged `in_progress` for ~10h on PRs #1231 and #1232 (check_run_id `86990436443`). It is the `solven-eu/cleanthat` GitHub App — a third-party service that creates check runs via the Checks API from its own backend, not a GitHub Actions workflow, so it cannot be moved to a self-hosted runner.

**How the disable works (verified against upstream source)**
In `github/.../refs/GithubRefCleaner.java`:
```java
var excludedPatterns = properties.getMeta().getRefs().getExcludedPatterns();
var optHeadMatchingRule = selectPatternOfSensibleHead(excludedPatterns, headRef);
if (optHeadMatchingRule.isPresent()) {
    LOGGER.info("We skip this event as head={} is excluded by {}", headRef, optHeadMatchingRule.get());
    return Optional.empty();   // <-- no check run created
}
```
`selectPatternOfSensibleHead` uses `java.util.regex.Pattern.matches(regex, fullRef)` (fully anchored), so `excluded_patterns: ["refs/heads/.*"]` matches every head ref and the App returns early in `prepareRefToClean()` — **before** `createCheckRun()` is reached in `GithubCheckRunManager`.

**Proof this PR works**
If the `Cleanthat` check does NOT appear on this PR, the disable is effective. If it does appear, the App is reading config from somewhere else and the config needs a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository cleanup configuration that disables automated processing and editing.
  * Prevented cleanup actions on all branch heads and disabled full repository reprocessing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->