### PR TITLE
modernize CleanThat configuration

### DIFF
--- a/.cleanthat/cleanthat.yaml
+++ b/.cleanthat/cleanthat.yaml
@@ -1,31 +1,20 @@
-syntax_version: "2021-08-02"
+syntax_version: "2023-01-09"
 meta:
   labels:
     - "cleanthat"
   refs:
-    branches:
-      - "refs/heads/develop"
-      - "refs/heads/main"
-      - "refs/heads/master"
+    protected_patterns:
+      - "develop"
+      - "main"
+      - "master"
 source_code:
   excludes: []
-  includes: []
   encoding: "UTF-8"
-  line_ending: "UNKNOWN"
-languages:
-  - language: "json"
-    language_version: "0"
+  line_ending: "GIT"
+engines:
+  - engine: "spotless"
     skip: false
-    source_code:
-      excludes: []
-      includes: []
-      encoding: "UTF-8"
-      line_ending: "UNKNOWN"
-    processors:
-      - engine: "jackson"
+    steps:
+      - id: "spotless"
         parameters:
-          indent: -1
-          indentation: "    "
-          space_before_separator: true
-          alphabetical_order: false
-          eol_at_eof: false
+          configuration: "repository:/.cleanthat/spotless.yaml"

--- a/.cleanthat/spotless.yaml
+++ b/.cleanthat/spotless.yaml
@@ -1,0 +1,11 @@
+syntax_version: "2023-01-14"
+encoding: "UTF-8"
+line_ending: "GIT_ATTRIBUTES"
+formatters:
+  - format: "json"
+    includes:
+      - "**/*.json"
+    steps:
+      - id: "jackson"
+        parameters:
+          space_before_separator: true


### PR DESCRIPTION
Updates CleanThat from the legacy 2021 language/processor schema to the current 2023 engine schema used by the hosted GitHub App.

The JSON policy remains backed by Spotless Jackson formatting and applies to all JSON files.

Validation:
- parsed both YAML files successfully
- `git diff --check`
- matched current upstream CleanThat configuration structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting configuration and protected branch settings.
  * Added standardized JSON formatting with consistent encoding, line endings, and spacing.
  * Simplified formatting rules and centralized formatter behavior for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->